### PR TITLE
Configure `req2flatpak` script/entry point.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ authors = ["johannesjh <johannesjh@users.noreply.github.com>"]
 license = "MIT"
 readme = "README.md"
 
+[tool.poetry.scripts]
+req2flatpak = 'req2flatpak:main'
+
 [tool.poetry.dependencies]
 python = "^3.10"
 packaging = "^21.3"


### PR DESCRIPTION
Installing the poetry package will know install the command `req2flatpak` that executes the main function of the package.

* pyproject.toml