### PR TITLE
fixes commandline argument for requirements file

### DIFF
--- a/req2flatpak.py
+++ b/req2flatpak.py
@@ -624,8 +624,7 @@ def cli_parser() -> argparse.ArgumentParser:
         "-r",
         nargs="?",
         type=argparse.FileType("r"),
-        default=sys.stdin,
-        help="Requirements can be read from a specified requirements.txt file or from stdin.",
+        help="Requirements can be read from a specified requirements.txt file.",
     )
     parser.add_argument(
         "--target-platforms",

--- a/tests/test_pypi_client.py
+++ b/tests/test_pypi_client.py
@@ -54,7 +54,6 @@ class ExampleUsageTest(unittest.TestCase):
         # prepare mocked cache
         def mocked_shelve_open(*_, **__):
             """A mock version of ``shelve.open`` that returns a simple dict to be used as cache."""
-            print("here the mocked contextmgr")
             return contextlib.nullcontext(enter_result=self.cache)
 
         # test with caching


### PR DESCRIPTION
removes default value `sys.stdin` for the `--requirements-file` commandline argument

fixes #22