### PR TITLE
Expand `pyproject.toml` and adjust `ci.yml`.

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: Whether pre-commit shall be setup, too
     required: false
     default: false
+  install-options:
+    description: Additional arguments to pass to `poetry install`.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -37,7 +41,7 @@ runs:
       run: |
         poetry env use python3.10
         poetry about
-        poetry install --with dev
+        poetry install ${{ inputs.install-options }}
       shell: bash
 
     - name: Install pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,16 @@ jobs:
         uses: ./.github/actions/setup
         with:
           setup-pre-commit: true
+          # lint group will be installed anyways because it is not optional
+          install-options: --with lint
 
       - name: Run linters
+        run: make lint
+
+      - name: Install extras
+        run: poetry install --all-extras
+
+      - name: Lint with extra packages installed
         run: make lint
 
   test:
@@ -30,6 +38,8 @@ jobs:
       - name: Setup
         id: setup
         uses: ./.github/actions/setup
+        with:
+          install-options: --without lint
 
       - name: Run Tests
         run: make test
@@ -43,6 +53,8 @@ jobs:
       - name: Setup
         id: setup
         uses: ./.github/actions/setup
+        with:
+          install-options: --with docs
 
       - name: Build Docs
         run: make docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-        args: ["--profile", "black"]
 
   - repo: https://github.com/psf/black
     rev: 22.10.0
@@ -28,7 +27,6 @@ repos:
     hooks:
       - id: pydocstyle
         additional_dependencies: [toml]
-        args: ["--ignore=D202,D203,D205,D401,D212"]
 
   - repo: local
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,8 +1,0 @@
-[FORMAT]
-max-line-length=120
-
-[BASIC]
-good-names=
-    e,
-    f,
-    py

--- a/poetry.lock
+++ b/poetry.lock
@@ -74,11 +74,11 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "docutils"
-version = "0.17.1"
+version = "0.19"
 description = "Docutils -- Python Documentation Utilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.7"
 
 [[package]]
 name = "idna"
@@ -315,15 +315,14 @@ markdown = ["CommonMark (>=0.5.6)"]
 
 [[package]]
 name = "sphinx-rtd-theme"
-version = "1.0.0"
+version = "0.5.1"
 description = "Read the Docs theme for Sphinx"
 category = "dev"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+python-versions = "*"
 
 [package.dependencies]
-docutils = "<0.18"
-sphinx = ">=1.6"
+sphinx = "*"
 
 [package.extras]
 dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client"]
@@ -484,7 +483,7 @@ packaging = ["packaging"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "531e65a42723252e0de7664bc0b9c9d96815fb8794376a7825945aac7207672b"
+content-hash = "efe390a9f4cbc929423e32d41e67473c5a934e806420b520226f24af203838be"
 
 [metadata.files]
 alabaster = [
@@ -516,8 +515,8 @@ dill = [
     {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
 ]
 docutils = [
-    {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
-    {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
+    {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
+    {file = "docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -647,8 +646,8 @@ sphinx-argparse = [
     {file = "sphinx_argparse-0.3.2-py3-none-any.whl", hash = "sha256:499afb62d19966651e1e5d601ac912ca2bdfb43f5dad491305d84bef4414f4f4"},
 ]
 sphinx-rtd-theme = [
-    {file = "sphinx_rtd_theme-1.0.0-py2.py3-none-any.whl", hash = "sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8"},
-    {file = "sphinx_rtd_theme-1.0.0.tar.gz", hash = "sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c"},
+    {file = "sphinx_rtd_theme-0.5.1-py2.py3-none-any.whl", hash = "sha256:fa6bebd5ab9a73da8e102509a86f3fcc36dec04a0b52ea80e5a033b2aba00113"},
+    {file = "sphinx_rtd_theme-0.5.1.tar.gz", hash = "sha256:eda689eda0c7301a80cf122dad28b1861e5605cbf455558f3775e1e8200e83a5"},
 ]
 sphinx-rtd-theme-github-versions = [
     {file = "sphinx_rtd_theme_github_versions-1.1-py3-none-any.whl", hash = "sha256:23018e51a5d27ef4f69dd86314f73b19088f2cfd91c74a24db1517832233dc07"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,20 @@ req2flatpak = 'req2flatpak:main'
 
 [tool.poetry.dependencies]
 python = "^3.7.2"
-packaging = "^21.3"
+packaging = { version = "^21.3", optional = true}
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.group.lint.dependencies]
+pylint = "^2.15.5"
+
+# [tool.poetry.group.tests.dependencies]
+
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
 sphinx = "^5.3.0"
 sphinx-argparse = "^0.3.2"
 sphinx-rtd-theme-github-versions = "^1.1"
-pylint = "^2.15.5"
 
 [tool.poetry.extras]
 packaging = ["packaging"]
@@ -25,3 +32,15 @@ packaging = ["packaging"]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+profile = "black"
+skip_gitignore = true
+
+[tool.pydocstyle]
+ignore = ["D202", "D203", "D205", "D401", "D212"]
+
+[tool.pylint]
+format.max-line-length = 88
+main.disable = ["C0301"]            # ignore line-too-long
+basic.good-names = ["e", "f", "py"]


### PR DESCRIPTION
* pyproject.toml (tool.poetry): Add group `docs` and move matching deps to it.
	Rename group `dev` to `lint`. For testing deps another group named `tests` or
	`testing` could be added.

* pyproject.toml : Add configuration for `isort`, `pydocstyle` and `pylint`.

* .pylintrc : Remove because its config is now included in `pyproject.toml`.

* .pre-commit-config.yaml : Remove cmd options that are configured in `pyproject.toml`.

* .github/actions/setup/action.yml : Add input for passing additional args to `poetry install`.

* .github/workflows/ci.yml : Specify groups to install for each job. Their setup will be faster
	now because they don't install unnecessary deps.

* .github/workflows/ci.yml (jobs.lint): Lint a second time after installing extras (optional deps)