### PR TITLE
fixes sorting when architecture is None

### DIFF
--- a/req2flatpak.py
+++ b/req2flatpak.py
@@ -607,7 +607,7 @@ class FlatpakGenerator:
 
         def sources(downloads: Iterable[Download]) -> List[dict]:
             sorted_downloads = sorted(
-                downloads, key=lambda d: (d.package, d.version, d.arch)
+                downloads, key=lambda d: (d.package, d.version, d.arch or "")
             )
             return [source(download) for download in sorted_downloads]
 

--- a/req2flatpak.py
+++ b/req2flatpak.py
@@ -227,6 +227,17 @@ class Download(Requirement):
                 return "aarch64"
         return None
 
+    def __lt__(self, other):
+        """Makes this class sortable."""
+        # Note: Implementing __lt__ is sufficient to make a class sortable,
+        # see, e.g., https://stackoverflow.com/a/7152796
+
+        def sort_keys(download: Download) -> Tuple[str, str, str]:
+            """A tuple of package, version and architecture is used as key for sorting."""
+            return download.package, download.version, download.arch or ""
+
+        return sort_keys(self) < sort_keys(other)
+
 
 @dataclass(frozen=True)
 class Release(Requirement):
@@ -606,10 +617,7 @@ class FlatpakGenerator:
             return source
 
         def sources(downloads: Iterable[Download]) -> List[dict]:
-            sorted_downloads = sorted(
-                downloads, key=lambda d: (d.package, d.version, d.arch or "")
-            )
-            return [source(download) for download in sorted_downloads]
+            return [source(download) for download in sorted(downloads)]
 
         return {
             "name": module_name,


### PR DESCRIPTION
Problem: I encountered a typeerror when req2flatpak was trying to sort downloads and encountered downloads with architecture None.

```
./req2flatpak.py --requirements-file python3-main.txt --target-platforms 310-x86_64 310-aarch64 > python3-main.json
Traceback (most recent call last):
  File "/builds/johannesjh/favagtk/requirements/./req2flatpak.py", line 768, in <module>
    main()
  File "/builds/johannesjh/favagtk/requirements/./req2flatpak.py", line 761, in main
    build_module = FlatpakGenerator.build_module(requirements, downloads)
  File "/builds/johannesjh/favagtk/requirements/./req2flatpak.py", line 620, in build_module
    "sources": sources(downloads),
  File "/builds/johannesjh/favagtk/requirements/./req2flatpak.py", line 609, in sources
    sorted_downloads = sorted(
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

Solution: to fix sorting, this merge request converts a None value in the architecture field to an empty string when sorting downloads.

Note about a possible alternative implementation: I could alternatively implement `Download.__lt__` to make downloads sortable, as explained here https://stackoverflow.com/a/7152796