### PR TITLE
Fix invalid platforms in `main`.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: pylama
         name: pylama
-        entry: pylama
+        entry: poetry run pylama
         language: system
         types: [python]
 

--- a/req2flatpak.py
+++ b/req2flatpak.py
@@ -766,6 +766,7 @@ def main():
         DownloadChooser.wheel_or_sdist(release, platform)
         for release in releases
         for platform in platforms
+        if platform
     }
 
     # generate flatpak-builder build module


### PR DESCRIPTION
PlatformFactory might return `None` if a platform cannot be passed. This wasn't handled by the main function yet.

Also ensures that pylama runs in poetry env. 



* req2flatpak.py (main)