### PR TITLE
doc: how to remove pre-commit hook

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -127,7 +127,7 @@ Use `pre-commit <https://pre-commit.com/>`__ to prettify and lint the code befor
    pre-commit run
 
 
-If this doesn't work, you can disable pre-commit using ``pre-commit uninstall``.
+If this doesn't work, you can skip specific checks by prepending ``SKIP=<hook-id>`` like so: ``SKIP=poetry-lock git commit``. You can disable all hooks for a commit by using ``git commit -n`` or disable pre-commit entirely for the repository with ``pre-commit uninstall``.
 We welcome your contributions even if your workflow differs from what we recommend here.
 
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -127,6 +127,10 @@ Use `pre-commit <https://pre-commit.com/>`__ to prettify and lint the code befor
    pre-commit run
 
 
+If this doesn't work, you can disable pre-commit using ``pre-commit uninstall``.
+We welcome your contributions even if your workflow differs from what we recommend here.
+
+
 Publishing a Release
 --------------------
 


### PR DESCRIPTION
This would've been useful to me when I was trying to commit in a hurry when playing with `pre-commit` for the first time.