### PR TITLE
docs: instructs users to install from pypi by default.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ using pip.
 Getting Started
 ---------------
 
-Run ``pip install git+https://github.com/johannesjh/req2flatpak``
-to install the latest development version of req2flatpak.
+Run ``pip install req2flatpak``
+to install the latest release of req2flatpak.
 
 It is possible to use req2flatpak from the commandline,
 as well as programmatically from a python script.

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -48,7 +48,7 @@ Installing Dependencies
 -----------------------
 
 req2flatpak depends on very few other software packages, as documented in req2flatpak's ``pyproject.toml`` file.
-Run ``poetry install`` to install these packages into a virtual environment.
+Run ``poetry install`` to install these packages into a python virtual environment.
 
 
 Running a Development Version

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -15,17 +15,39 @@ For example:
 
 .. code-block:: bash
 
-   pip install git+https://github.com/johannesjh/req2flatpak
+   pip install req2flatpak
    req2flatpak --help
 
 
-The first command will install the latest development version of req2flatpak.
+The first command will install the latest release of req2flatpak.
 The second command will display req2flatpak's help,
 allowing you to verify that req2flatpak was installed successfully.
 
 
-Simply Downloading or Copying the Script
-----------------------------------------
+Installing from Git
+-------------------
 
-You can download the req2flatpak script to your computer and run it.
+It is possible to install req2flatpak from a git repository.
+This installation method is useful if you want to install and test
+a new, experimental version of req2flatpak that has not yet been officially released.
+
+To install req2flatpak from a git repository, run this command:
+
+.. code-block:: bash
+
+   pip install git+https://github.com/johannesjh/req2flatpak
+
+
+The above command will install req2flatpak from the git repository's main branch.
+
+You can, of course, specify other git repositories,
+for example in order to install from a forked repository of req2flatpak.
+And it is possible to specify specific branches, commits and tags,
+see `pip's documentation on VCS support <https://pip.pypa.io/en/stable/topics/vcs-support/>`_.
+
+
+Simply Downloading and Copying the Script
+-----------------------------------------
+
+You can download the ``req2flatpak.py`` script to your computer and run it.
 Simple as that.


### PR DESCRIPTION
This pull request improves documentation by instructing users to install an official release from pypi. Previously, users were instructed to install from the git main branch.