### PR TITLE
adds a changelog

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,34 @@
+Changelog
+=========
+
+..
+   This changelog is written by hand.
+   Newest releases are added to the top of the file.
+
+
+v0.2 (unreleased) "Yaml"
+------------------------
+
+Highlight: req2flatpak can now generate yaml output.
+
+Features:
+
+- Adds yaml output.
+  It is now possible to generate yaml output by specifying a ``.yaml`` file extension
+  or by specifying the ``--yaml`` commandline option.
+
+Bugfixes:
+
+- Fixes sorting when architecture is None - `#34 <https://github.com/johannesjh/req2flatpak/pull/34>`_
+- Fixes exception handling with invalid platforms - `#39 <https://github.com/johannesjh/req2flatpak/pull/39>`_
+
+
+v0.1 (2022-12-23) "Initial Release"
+-----------------------------------
+
+Highlight: This is the initial release of req2flatpak.
+
+Features:
+
+- Generates a flatpak-builder build module for given python package requirements; the module will install the required packages as part of a flatpak build.
+- This initial release already comes with documentation, a clean code style, and automated tests that are run using continuous integration.

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -137,6 +137,7 @@ Publishing a Release
 Use the following steps to publish a release of req2flatpak:
 
 * Enter the version number to be released in ``pyproject.toml``, e.g., ``version = "1.2.3"``. Commit and push this change to a branch and create a merge request.
-* Verify that the branch builds correctly. Ideally run some manual tests. Optionally tag a release candidate by pushing a tag such as v1.2.3-rc1. If the quality looks good, merge the branch
+* Describe the release in ``docs/source/changelog.rst``. Commit and push the modified changelog in the same branch.
+* Verify that the branch builds correctly. Ideally run some manual tests. Optionally tag a release candidate by pushing a tag such as v1.2.3-rc1. If the quality looks good, merge the branch.
 * Tag the main branch with the version to be released, e.g., push a tag named ``v1.2.3``.
 * Github CI will build the python package and publish it on PyPI.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ req2flatpak Documentation
    cli
    api
    development
+   changelog
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version     = "0.1.0"
 description = "Generates a flatpak-builder build module for installing python packages defined in requirements.txt files."
 authors     = ["johannesjh <johannesjh@users.noreply.github.com>"]
 license     = "MIT"
-readme      = "README.rst"
+readme      = ["README.rst", "docs/source/changelog.rst"]
 
 [tool.poetry.scripts]
 req2flatpak = 'req2flatpak:main'


### PR DESCRIPTION
Adds a changelog. refs #53

* For the changelog, I simply added a new `.rst` file as part of req2flatpak's documentation.
* I wrote the file by hand because this is simpler than using tools. And changelog contents should be hand-crafted in my opinion, to make them useful for users.
* I added instructions in `docs/source/development.rst` so we don't forget to update the changelog when creating a release.

