### PR TITLE
Bump GitHub Actions to avoid node warnings

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -35,7 +35,7 @@ runs:
       if: github.event_name == 'push'
       # We pin to the github action's SHA, not the tag, for security reasons.
       # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-      uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ inputs.token }}
         publish_dir: .github/pages

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,14 +25,14 @@ runs:
       shell: bash
 
     - name: Checkout
-      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      uses: actions/checkout@v4
 
     - name: Install poetry
       run: pipx install poetry
       shell: bash
 
     - name: setup python
-      uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: "poetry"
@@ -54,7 +54,7 @@ runs:
       shell: bash
     - name: Configure Caching for Pre-Commit
       if: ${{ inputs.setup-pre-commit }}
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@v4
 
       - name: Setup
         id: setup
@@ -34,10 +34,10 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@v4
 
       - name: setup python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@v4
 
       - name: Setup
         id: setup
@@ -104,7 +104,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@v4
 
       - name: Setup
         id: setup


### PR DESCRIPTION
I also used `@vN`-style pins instead of the specific commits.  A few of these have crossed from v3 to v4 for example, generally for node16 -> node20 errors.

- - - -

When I ran the  pipeline manually under the "Actions" tab, I saw failures because of deprecated `node` versions.  E.g., https://github.com/johannesjh/req2flatpak/actions/runs/9828146035

![image](https://github.com/johannesjh/req2flatpak/assets/818622/a5db9135-f47f-4fa4-b4b3-e43cd2d3cb62)

Note sure why these don't fail on normal CI runs, maybe I just never noticed the warnings (I'm still getting used to have GitHub Actions differs from GitLab CI).

 - - - -

More importantly, @johannesjh: are you ok with using these `@v5` pins?  I think its a good balance between keeping things pinned but allow patch/minor releases.