### PR TITLE
Close stream to ensure file is written

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,16 @@ Changelog
    This changelog is written by hand.
    Newest releases are added to the top of the file.
 
+Unreleased (xxxx-xx-xx)
+-----------------------
+
+Fixes:
+
+- Close output stream which was causing empty outfile files on Python 3.14.
+
+
+Full Changelog: https://github.com/johannesjh/req2flatpak/compare/v0.3.1...main
+
 
 v0.3.1 (2025-03-30) "Python 3.12"
 ---------------------------------

--- a/req2flatpak.py
+++ b/req2flatpak.py
@@ -781,6 +781,7 @@ def main():  # pylint: disable=too-many-branches
         output_stream.write(
             FlatpakGenerator.build_module_as_str(requirements, downloads)
         )
+    output_stream.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On Fedora 43 with Python 3.14.0, I was getting empty .yaml and .json files.  I think its b/c the stream wasn't closed (or at least this change seems to have fixed it).