### PR TITLE
Update version constraint for packaging.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ req2flatpak = 'req2flatpak:main'
 
 [tool.poetry.dependencies]
 python    = ">=3.8"
-packaging = { version = "^21.3" }
+packaging = { version = ">=21.3" }
 pyyaml    = { version = "^6.0.1", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
When trying to use `pip-tools` and `req2flatpak` in the same venv (which is somewhat likely), one gets the following error message from pip:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
pyproject-metadata 0.11.0 requires packaging>=23.2, but you have packaging 21.3 which is incompatible.
```

This is because `req2flatpak` pins the version to `^21.3`, however it works perfectly fine with the latest version.

The pin is unnecessarily strict for such a widely used package, especially since it uses calender-based versioning (so using `^` doesn't make sense here anyway) and it is maintained by PyPA, so sudden breakages without a deprecation period are highly unlikely.